### PR TITLE
Add OAuth (U2M browser login / SSO) authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ Or install from ZIP: download [`databricks_dbsql_connector.zip`](https://github.
 - [Walkthrough (Mac)](https://www.youtube.com/watch?v=M5ZvVWpZnQY)
 - [Windows installation](https://www.youtube.com/watch?v=zpyWuKZTePQ)
 
+## What's New in v1.4.0
+
+### OAuth Authentication (Browser Login / SSO)
+- **Auth Method selector**: Choose **Personal Access Token** or **OAuth (browser login / SSO)** per connection
+- **No token required for OAuth**: Sign in through your browser (including SSO/identity provider) — the plugin caches and refreshes the session automatically, so the browser opens only once
+- **Sign in button**: Prime the OAuth flow up front before discovering tables or loading layers
+- **Reused everywhere**: The cached OAuth session powers Test Connection, table discovery, layer loads, live-layer refreshes, the Browser panel, and Genie
+- **Secure-by-default storage**: Tokens are written to a permission-restricted file under your QGIS profile directory
+- **Fully backwards compatible**: Existing Personal Access Token connections and saved layers keep working unchanged
+
 ## What's New in v1.3.0
 
 ### Genie Chat (Natural Language Data Queries)
@@ -56,7 +66,7 @@ Or install from ZIP: download [`databricks_dbsql_connector.zip`](https://github.
 ## Features
 
 - **Genie Chat**: Ask questions in natural language — Genie returns SQL results you can visualise as layers
-- **Direct Databricks SQL Connection**: Connect directly to Databricks SQL warehouses using personal access tokens
+- **Direct Databricks SQL Connection**: Connect directly to Databricks SQL warehouses using a personal access token or OAuth (browser login / SSO)
 - **Spatial Data Support**: Full support for GEOGRAPHY and GEOMETRY data types
 - **Live Layers**: Viewport-based auto-refresh — layers update automatically as you pan and zoom
 - **Multiple Access Methods**: Load data via Dialog, Browser Panel, or Custom Query interface
@@ -84,7 +94,7 @@ Or install from ZIP: download [`databricks_dbsql_connector.zip`](https://github.
 
 ### Databricks Requirements
 - Databricks SQL Warehouse access (Serverless recommended for best performance)
-- Personal Access Token with appropriate permissions
+- Authentication: a Personal Access Token, or OAuth (browser login / SSO) — no token needed for OAuth
 - Unity Catalog tables with GEOGRAPHY or GEOMETRY columns
 
 ## Installation
@@ -131,11 +141,28 @@ If automatic dependency installation fails:
    - **Connection Name**: A friendly name for saving this connection
    - **Server Hostname**: Your Databricks workspace hostname (e.g., `your-workspace.cloud.databricks.com`)
    - **HTTP Path**: The SQL warehouse HTTP path (e.g., `/sql/1.0/warehouses/your-warehouse-id`)
-   - **Access Token**: Your Databricks personal access token (starts with `dapi`)
+   - **Auth Method**: Choose how to authenticate (see below)
+   - **Access Token**: *(Personal Access Token only)* Your Databricks token (starts with `dapi`)
 
 3. **Test the connection** by clicking "Test Connection"
 
 4. **Save the connection** to persist settings
+
+#### Authentication methods
+
+The **Auth Method** dropdown lets you pick how the plugin authenticates:
+
+- **Personal Access Token (PAT)** — paste a token that starts with `dapi`. Simplest option;
+  the token is stored with the saved connection.
+- **OAuth (browser login / SSO)** — no token needed. The first connection (or clicking
+  **Sign in**) opens your browser to authenticate against your Databricks workspace, including
+  any SSO/identity provider. The plugin caches the resulting tokens in a
+  permission-restricted file under your QGIS profile directory and refreshes them automatically,
+  so the browser only opens once. The same cached session is reused for Test Connection,
+  table discovery, layer loads, live-layer refreshes, the Browser panel, and Genie.
+
+> **Tip:** With OAuth selected, use **Sign in** once before discovering tables so the browser
+> sign-in happens up front rather than mid-operation.
 
 ### Loading Data
 
@@ -189,9 +216,17 @@ If automatic dependency installation fails:
 ## Troubleshooting
 
 ### "Connection failed"
-- Verify hostname, HTTP path, and access token
+- Verify hostname and HTTP path (and access token if using Personal Access Token auth)
 - Check network connectivity to Databricks
 - Ensure the SQL warehouse is running
+
+### OAuth sign-in issues
+- The browser must be able to open and redirect to `http://localhost:<port>` — if no browser
+  appears, check that QGIS is not running in a headless/remote session
+- If sign-in succeeds but later connections fail, delete the cached token file
+  (`databricks_oauth_tokens.json` in your QGIS profile directory) and click **Sign in** again
+- OAuth (browser login) requires an interactive desktop session; for unattended/headless use,
+  use a Personal Access Token instead
 
 ### "No spatial tables found"
 - Verify Unity Catalog access permissions
@@ -212,6 +247,7 @@ qgis-databricks-connector/
 ├── databricks_dbsql_connector/    # Plugin folder
 │   ├── __init__.py                # Plugin entry point
 │   ├── _qt6_compat.py             # Qt5/Qt6 compatibility shims
+│   ├── databricks_auth.py         # Central auth factory + OAuth token persistence
 │   ├── metadata.txt               # Plugin metadata
 │   ├── LICENSE                    # MIT License
 │   ├── databricks_connector.py    # Main plugin class

--- a/databricks_dbsql_connector/databricks_auth.py
+++ b/databricks_dbsql_connector/databricks_auth.py
@@ -1,0 +1,245 @@
+"""Centralised authentication for the Databricks DBSQL Connector.
+
+All Databricks connections in the plugin are built through this module so that
+the choice of authentication method lives in exactly one place. Two methods are
+supported:
+
+* ``pat``       - Personal Access Token (the original behaviour).
+* ``oauth_u2m`` - OAuth User-to-Machine (interactive browser login / SSO).
+
+For OAuth U2M the underlying ``databricks-sql-connector`` opens a browser the
+first time and exchanges the code for an access + refresh token. Because QGIS
+opens many short-lived connections (test, discover, every layer load, every
+live-layer viewport refresh, Genie), we persist those tokens to a
+permission-restricted JSON file under the active QGIS profile directory and key
+them by hostname. Subsequent connections read the cached refresh token and
+renew silently, so the browser only appears once.
+
+The bearer token cached by this flow is also reused for Genie's REST API calls,
+which need an ``Authorization: Bearer`` header rather than a SQL connection.
+"""
+
+import base64
+import json
+import os
+import stat
+import threading
+
+# Authentication method identifiers (stored in QSettings and layer properties).
+AUTH_PAT = "pat"
+AUTH_OAUTH_U2M = "oauth_u2m"
+
+# Human-readable labels for the UI combo box, in display order.
+AUTH_METHOD_LABELS = [
+    ("Personal Access Token", AUTH_PAT),
+    ("OAuth (browser login / SSO)", AUTH_OAUTH_U2M),
+]
+
+# auth_type value understood by databricks-sql-connector for U2M OAuth.
+_DATABRICKS_OAUTH_AUTH_TYPE = "databricks-oauth"
+
+# Refresh the bearer token this many seconds before it actually expires, so a
+# request never goes out with a token that lapses mid-flight.
+_TOKEN_EXPIRY_MARGIN_SECONDS = 120
+
+_persistence_lock = threading.Lock()
+
+
+def normalise_auth_method(value):
+    """Coerce a stored/blank auth-method value to a known identifier.
+
+    Older saved connections and layers predate this field, so a missing or
+    unrecognised value falls back to PAT to preserve existing behaviour.
+    """
+    if value == AUTH_OAUTH_U2M:
+        return AUTH_OAUTH_U2M
+    return AUTH_PAT
+
+
+def _profile_oauth_token_path():
+    """Return the path to the OAuth token cache inside the QGIS profile dir."""
+    try:
+        from qgis.core import QgsApplication
+
+        base_dir = QgsApplication.qgisSettingsDirPath()
+    except Exception:
+        base_dir = os.path.join(os.path.expanduser("~"), ".qgis-databricks")
+    if not base_dir:
+        base_dir = os.path.join(os.path.expanduser("~"), ".qgis-databricks")
+    return os.path.join(base_dir, "databricks_oauth_tokens.json")
+
+
+def _restrict_permissions(path):
+    """Best-effort lock down of the token cache to the current user (0600)."""
+    try:
+        os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
+    except OSError:
+        pass
+
+
+def _make_oauth_persistence():
+    """Build a QgisOAuthPersistence, or ``None`` if the connector is absent."""
+    try:
+        from databricks.sql.experimental.oauth_persistence import (
+            OAuthPersistence,
+            OAuthToken,
+        )
+    except Exception:
+        return None
+
+    class QgisOAuthPersistence(OAuthPersistence):
+        """Persist OAuth tokens to a per-user JSON file keyed by hostname."""
+
+        def __init__(self, path):
+            self._path = path
+
+        def _load_all(self):
+            try:
+                with open(self._path, "r", encoding="utf-8") as handle:
+                    data = json.load(handle)
+                    return data if isinstance(data, dict) else {}
+            except (OSError, ValueError):
+                return {}
+
+        def persist(self, hostname, oauth_token):
+            with _persistence_lock:
+                data = self._load_all()
+                data[hostname] = {
+                    "access_token": oauth_token.access_token,
+                    "refresh_token": oauth_token.refresh_token,
+                }
+                directory = os.path.dirname(self._path)
+                if directory and not os.path.isdir(directory):
+                    os.makedirs(directory, exist_ok=True)
+                with open(self._path, "w", encoding="utf-8") as handle:
+                    json.dump(data, handle)
+                _restrict_permissions(self._path)
+
+        def read(self, hostname):
+            with _persistence_lock:
+                entry = self._load_all().get(hostname)
+            if not entry:
+                return None
+            return OAuthToken(
+                entry.get("access_token"), entry.get("refresh_token")
+            )
+
+    return QgisOAuthPersistence(_profile_oauth_token_path())
+
+
+def connect_kwargs(hostname, http_path, access_token=None, auth_method=AUTH_PAT):
+    """Build the keyword arguments for ``databricks.sql.connect``.
+
+    The caller does ``sql.connect(**connect_kwargs(...))`` regardless of the
+    auth method, so call sites no longer hard-code PAT.
+    """
+    method = normalise_auth_method(auth_method)
+    kwargs = {"server_hostname": hostname, "http_path": http_path}
+    if method == AUTH_OAUTH_U2M:
+        kwargs["auth_type"] = _DATABRICKS_OAUTH_AUTH_TYPE
+        persistence = _make_oauth_persistence()
+        if persistence is not None:
+            kwargs["experimental_oauth_persistence"] = persistence
+        return kwargs
+    kwargs["access_token"] = access_token
+    return kwargs
+
+
+def connect_kwargs_from_config(config):
+    """Convenience wrapper for the dict shape used across the plugin."""
+    return connect_kwargs(
+        config.get("hostname"),
+        config.get("http_path"),
+        config.get("access_token"),
+        config.get("auth_method", AUTH_PAT),
+    )
+
+
+def prime_oauth(hostname, http_path, auth_method=AUTH_OAUTH_U2M):
+    """Run the interactive OAuth flow once and cache the tokens.
+
+    Opens a single ``sql.connect`` so the browser login (and token persistence)
+    happens up front, before background threads start opening their own
+    connections and racing to launch competing browser windows. Returns a
+    ``(success, message)`` tuple. Safe to call on a worker thread.
+    """
+    if normalise_auth_method(auth_method) != AUTH_OAUTH_U2M:
+        return True, "No interactive sign-in required for this auth method."
+    try:
+        from databricks import sql
+    except Exception:
+        return False, "databricks-sql-connector is not installed."
+    try:
+        connection = sql.connect(
+            **connect_kwargs(hostname, http_path, auth_method=AUTH_OAUTH_U2M)
+        )
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT 1")
+            cursor.fetchone()
+        connection.close()
+        return True, "Signed in to Databricks successfully."
+    except Exception as exc:  # noqa: BLE001 - surfaced to the user
+        return False, "Sign-in failed: {}".format(exc)
+
+
+def _jwt_seconds_until_expiry(token):
+    """Return seconds until a JWT access token expires, or ``None`` if unknown.
+
+    Reads the unsigned ``exp`` claim only; no signature verification is needed
+    because we are merely deciding whether to refresh proactively.
+    """
+    try:
+        payload_segment = token.split(".")[1]
+        padding = "=" * (-len(payload_segment) % 4)
+        decoded = base64.urlsafe_b64decode(payload_segment + padding)
+        exp = json.loads(decoded).get("exp")
+    except Exception:
+        return None
+    if not exp:
+        return None
+    try:
+        import time
+
+        return int(exp) - int(time.time())
+    except Exception:
+        return None
+
+
+def get_bearer_token(hostname, http_path, access_token=None, auth_method=AUTH_PAT):
+    """Return a bearer token for Databricks REST calls (used by Genie).
+
+    For PAT this is just the token. For OAuth U2M it returns the cached access
+    token, refreshing it through a lightweight ``sql.connect`` ping when the
+    cached token is missing or about to expire.
+    """
+    method = normalise_auth_method(auth_method)
+    if method != AUTH_OAUTH_U2M:
+        return access_token
+
+    persistence = _make_oauth_persistence()
+    cached = persistence.read(hostname) if persistence is not None else None
+    token = cached.access_token if cached is not None else None
+
+    seconds_left = _jwt_seconds_until_expiry(token) if token else None
+    needs_refresh = (
+        token is None
+        or (seconds_left is not None and seconds_left < _TOKEN_EXPIRY_MARGIN_SECONDS)
+    )
+    if needs_refresh and http_path:
+        # A real connection forces the connector to refresh and re-persist.
+        try:
+            from databricks import sql
+
+            connection = sql.connect(
+                **connect_kwargs(hostname, http_path, auth_method=AUTH_OAUTH_U2M)
+            )
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT 1")
+                cursor.fetchone()
+            connection.close()
+            cached = persistence.read(hostname) if persistence is not None else None
+            token = cached.access_token if cached is not None else token
+        except Exception:
+            # Fall back to whatever we had cached; the caller surfaces errors.
+            pass
+    return token

--- a/databricks_dbsql_connector/databricks_browser.py
+++ b/databricks_dbsql_connector/databricks_browser.py
@@ -21,6 +21,11 @@ except ImportError:
     DATABRICKS_AVAILABLE = False
 
 from .databricks_dialog import DatabricksQueryDialog
+from .databricks_auth import (
+    AUTH_PAT,
+    normalise_auth_method,
+    connect_kwargs_from_config,
+)
 
 
 class DatabricksConnectionItem(QgsDataCollectionItem):
@@ -78,9 +83,7 @@ class DatabricksConnectionItem(QgsDataCollectionItem):
         """Get list of accessible catalogs using information_schema (same as custom query dialog)"""
         try:
             connection = sql.connect(
-                server_hostname=self.connection_config['hostname'],
-                http_path=self.connection_config['http_path'],
-                access_token=self.connection_config['access_token']
+                **connect_kwargs_from_config(self.connection_config)
             )
             
             with connection.cursor() as cursor:
@@ -188,9 +191,7 @@ class DatabricksCatalogItem(QgsDataCollectionItem):
         """Get list of schemas in this catalog using information_schema"""
         try:
             connection = sql.connect(
-                server_hostname=self.connection_config['hostname'],
-                http_path=self.connection_config['http_path'],
-                access_token=self.connection_config['access_token']
+                **connect_kwargs_from_config(self.connection_config)
             )
             
             with connection.cursor() as cursor:
@@ -278,9 +279,7 @@ class DatabricksSchemaItem(QgsDataCollectionItem):
         """Get list of tables in this schema with geometry information using system.information_schema"""
         try:
             connection = sql.connect(
-                server_hostname=self.connection_config['hostname'],
-                http_path=self.connection_config['http_path'],
-                access_token=self.connection_config['access_token']
+                **connect_kwargs_from_config(self.connection_config)
             )
             
             tables = {}  # Use dict to store table information
@@ -421,9 +420,7 @@ class DatabricksTableItem(QgsDataCollectionItem):
         try:
             # Get table schema from Databricks
             connection = sql.connect(
-                server_hostname=self.connection_config['hostname'],
-                http_path=self.connection_config['http_path'],
-                access_token=self.connection_config['access_token']
+                **connect_kwargs_from_config(self.connection_config)
             )
             
             with connection.cursor() as cursor:
@@ -536,9 +533,7 @@ class DatabricksTableItem(QgsDataCollectionItem):
             
             # Connect to Databricks
             connection = sql.connect(
-                server_hostname=self.connection_config['hostname'],
-                http_path=self.connection_config['http_path'],
-                access_token=self.connection_config['access_token']
+                **connect_kwargs_from_config(self.connection_config)
             )
             
             with connection.cursor() as cursor:
@@ -815,7 +810,9 @@ class DatabricksTableItem(QgsDataCollectionItem):
             layer.setCustomProperty("databricks/hostname", self.connection_config.get('hostname', ''))
             layer.setCustomProperty("databricks/http_path", self.connection_config.get('http_path', ''))
             layer.setCustomProperty("databricks/access_token", self.connection_config.get('access_token', ''))
-            
+            layer.setCustomProperty("databricks/auth_method",
+                                    normalise_auth_method(self.connection_config.get('auth_method', AUTH_PAT)))
+
             # Store table info
             full_name = f"{self.catalog_name}.{self.schema_name}.{self.table_name}"
             layer.setCustomProperty("databricks/full_name", full_name)
@@ -872,9 +869,7 @@ class DatabricksTableItem(QgsDataCollectionItem):
 
             # Connect to Databricks to get schema + sample geometries
             connection = sql.connect(
-                server_hostname=self.connection_config['hostname'],
-                http_path=self.connection_config['http_path'],
-                access_token=self.connection_config['access_token']
+                **connect_kwargs_from_config(self.connection_config)
             )
 
             table_ref = self._get_table_reference()
@@ -1177,11 +1172,16 @@ class DatabricksRootItem(QgsDataCollectionItem):
                 connection_config = {
                     'hostname': settings.value("hostname", ""),
                     'http_path': settings.value("http_path", ""),
-                    'access_token': settings.value("access_token", "")
+                    'access_token': settings.value("access_token", ""),
+                    'auth_method': normalise_auth_method(
+                        settings.value("auth_method", AUTH_PAT))
                 }
                 settings.endGroup()
-                
-                if all(connection_config.values()):  # Only add if all required fields are present
+
+                # Require host + path, and a token only for PAT auth.
+                token_ok = (bool(connection_config['access_token'])
+                            or connection_config['auth_method'] != AUTH_PAT)
+                if connection_config['hostname'] and connection_config['http_path'] and token_ok:
                     conn_item = DatabricksConnectionItem(self, conn_name, connection_config)
                     children.append(conn_item)
             

--- a/databricks_dbsql_connector/databricks_connector.py
+++ b/databricks_dbsql_connector/databricks_connector.py
@@ -31,6 +31,7 @@ BROWSER_AVAILABLE = True  # Assume it's available, import when needed
 BROWSER_IMPORT_ERROR = None
 
 from .databricks_dialog import DatabricksDialog
+from .databricks_auth import AUTH_PAT, normalise_auth_method, connect_kwargs
 
 
 class DatabricksConnector:
@@ -512,29 +513,34 @@ class DatabricksConnector:
             hostname = layer.customProperty("databricks/hostname", "")
             http_path = layer.customProperty("databricks/http_path", "")
             access_token = layer.customProperty("databricks/access_token", "")
+            auth_method = normalise_auth_method(
+                layer.customProperty("databricks/auth_method", AUTH_PAT))
             full_name = layer.customProperty("databricks/full_name", "")
             geometry_column = layer.customProperty("databricks/geometry_column", "")
             max_features_str = layer.customProperty("databricks/max_features", "0")
-            
-            if not all([hostname, http_path, access_token, full_name]):
+
+            token_ok = bool(access_token) or auth_method != AUTH_PAT
+            if not all([hostname, http_path, full_name]) or not token_ok:
                 QgsMessageLog.logMessage(
                     f"Skipping layer '{layer.name()}' - missing connection info",
                     "Databricks Connector",
                     Qgis.Warning
                 )
                 continue
-            
+
             try:
                 max_features = int(max_features_str)
             except ValueError:
                 max_features = 0
-            
+
             # Perform refresh
-            self._do_refresh_layer(layer, hostname, http_path, access_token, 
-                                   full_name, geometry_column, max_features)
-    
-    def _do_refresh_layer(self, layer, hostname, http_path, access_token, 
-                          full_name, geometry_column, max_features):
+            self._do_refresh_layer(layer, hostname, http_path, access_token,
+                                   full_name, geometry_column, max_features,
+                                   auth_method=auth_method)
+
+    def _do_refresh_layer(self, layer, hostname, http_path, access_token,
+                          full_name, geometry_column, max_features,
+                          auth_method=AUTH_PAT):
         """Actually perform the layer refresh operation"""
         try:
             if not DATABRICKS_AVAILABLE:
@@ -562,9 +568,7 @@ class DatabricksConnector:
             
             # Connect to Databricks
             connection = sql.connect(
-                server_hostname=hostname,
-                http_path=http_path,
-                access_token=access_token
+                **connect_kwargs(hostname, http_path, access_token, auth_method)
             )
             
             # Escape identifiers helper
@@ -775,10 +779,15 @@ class DatabricksConnector:
                 connection_config = {
                     'hostname': layer.customProperty("databricks/hostname", ""),
                     'http_path': layer.customProperty("databricks/http_path", ""),
-                    'access_token': layer.customProperty("databricks/access_token", "")
+                    'access_token': layer.customProperty("databricks/access_token", ""),
+                    'auth_method': normalise_auth_method(
+                        layer.customProperty("databricks/auth_method", AUTH_PAT))
                 }
-                
-                if not all(connection_config.values()):
+
+                _token_ok = (bool(connection_config['access_token'])
+                             or connection_config['auth_method'] != AUTH_PAT)
+                if not (connection_config['hostname'] and connection_config['http_path']
+                        and _token_ok):
                     QMessageBox.warning(
                         self.iface.mainWindow(),
                         "Missing Connection Info",

--- a/databricks_dbsql_connector/databricks_dialog.py
+++ b/databricks_dbsql_connector/databricks_dialog.py
@@ -27,6 +27,16 @@ try:
 except ImportError:
     DATABRICKS_AVAILABLE = False
 
+from .databricks_auth import (
+    AUTH_PAT,
+    AUTH_OAUTH_U2M,
+    AUTH_METHOD_LABELS,
+    normalise_auth_method,
+    connect_kwargs,
+    connect_kwargs_from_config,
+    prime_oauth,
+)
+
 try:
     from shapely import wkt
     SHAPELY_AVAILABLE = True
@@ -78,24 +88,24 @@ class ConnectionTestThread(QThread):
     
     finished = pyqtSignal(bool, str)  # success, message
     
-    def __init__(self, hostname, http_path, access_token):
+    def __init__(self, hostname, http_path, access_token, auth_method=AUTH_PAT):
         super().__init__()
         self.hostname = hostname
         self.http_path = http_path
         self.access_token = access_token
-    
+        self.auth_method = auth_method
+
     def run(self):
         if not DATABRICKS_AVAILABLE:
             self.finished.emit(False, "databricks-sql-connector not installed")
             return
-            
+
         try:
             connection = sql.connect(
-                server_hostname=self.hostname,
-                http_path=self.http_path,
-                access_token=self.access_token
+                **connect_kwargs(self.hostname, self.http_path,
+                                 self.access_token, self.auth_method)
             )
-            
+
             # Test with a simple query
             with connection.cursor() as cursor:
                 cursor.execute("SELECT 1")
@@ -113,25 +123,25 @@ class TableDiscoveryThread(QThread):
     
     finished = pyqtSignal(list)  # list of table info dicts
     
-    def __init__(self, hostname, http_path, access_token):
+    def __init__(self, hostname, http_path, access_token, auth_method=AUTH_PAT):
         super().__init__()
         self.hostname = hostname
         self.http_path = http_path
         self.access_token = access_token
-    
+        self.auth_method = auth_method
+
     def run(self):
         tables = []
         if not DATABRICKS_AVAILABLE:
             self.finished.emit(tables)
             return
-            
+
         try:
             connection = sql.connect(
-                server_hostname=self.hostname,
-                http_path=self.http_path,
-                access_token=self.access_token
+                **connect_kwargs(self.hostname, self.http_path,
+                                 self.access_token, self.auth_method)
             )
-            
+
             with connection.cursor() as cursor:
                 # Query to find tables with spatial columns
                 query = """
@@ -177,11 +187,12 @@ class LayerLoadingThread(QThread):
     progress = pyqtSignal(str)  # progress message
     finished = pyqtSignal(bool, str, object)  # success, message, layer_object
     
-    def __init__(self, hostname, http_path, access_token, table_info, layer_name, max_features=1000):
+    def __init__(self, hostname, http_path, access_token, table_info, layer_name, max_features=1000, auth_method=AUTH_PAT):
         super().__init__()
         self.hostname = hostname
         self.http_path = http_path
         self.access_token = access_token
+        self.auth_method = auth_method
         self.table_info = table_info
         self.layer_name = layer_name
         self.max_features = max_features
@@ -214,13 +225,12 @@ class LayerLoadingThread(QThread):
         
         try:
             self.progress.emit("Connecting to Databricks...")
-            
+
             connection = sql.connect(
-                server_hostname=self.hostname,
-                http_path=self.http_path,
-                access_token=self.access_token
+                **connect_kwargs(self.hostname, self.http_path,
+                                 self.access_token, self.auth_method)
             )
-            
+
             # If geometry type is generic, detect actual type from sample data
             if self.table_info['geometry_type'].upper().startswith('GEOMETRY'):
                 self._detect_mixed_geometry_types(connection)
@@ -787,9 +797,24 @@ class LayerLoadingThread(QThread):
             return 1  # Point for unknown types
 
 
+class OAuthSignInThread(QThread):
+    """Thread that runs the interactive OAuth sign-in and caches the token."""
+
+    finished = pyqtSignal(bool, str)  # success, message
+
+    def __init__(self, hostname, http_path):
+        super().__init__()
+        self.hostname = hostname
+        self.http_path = http_path
+
+    def run(self):
+        success, message = prime_oauth(self.hostname, self.http_path, AUTH_OAUTH_U2M)
+        self.finished.emit(success, message)
+
+
 class DatabricksDialog(QDialog):
     """Main dialog for Databricks connector with connection persistence"""
-    
+
     def __init__(self, iface):
         super().__init__()
         self.iface = iface
@@ -834,38 +859,64 @@ class DatabricksDialog(QDialog):
         self.http_path_edit = QLineEdit()
         self.http_path_edit.setPlaceholderText("/sql/1.0/warehouses/your-warehouse-id")
         conn_layout.addWidget(self.http_path_edit, 3, 1)
-        
-        conn_layout.addWidget(QLabel("Access Token:"), 4, 0)
+
+        # Authentication method selector
+        conn_layout.addWidget(QLabel("Auth Method:"), 4, 0)
+        self.auth_method_combo = QComboBox()
+        for label, _value in AUTH_METHOD_LABELS:
+            self.auth_method_combo.addItem(label)
+        self.auth_method_combo.currentIndexChanged.connect(self._on_auth_method_changed)
+        conn_layout.addWidget(self.auth_method_combo, 4, 1)
+
+        # Access token row (only shown for Personal Access Token auth)
+        self.access_token_label = QLabel("Access Token:")
+        conn_layout.addWidget(self.access_token_label, 5, 0)
         self.access_token_edit = QLineEdit()
         self.access_token_edit.setEchoMode(QLineEdit.Password)
         self.access_token_edit.setPlaceholderText("dapi... (personal access token)")
-        conn_layout.addWidget(self.access_token_edit, 4, 1)
-        
+        conn_layout.addWidget(self.access_token_edit, 5, 1)
+
+        # OAuth hint row (only shown for OAuth auth)
+        self.oauth_hint_label = QLabel(
+            "A browser window opens for sign-in. Use \"Sign in\" or "
+            "\"Test Connection\" to authenticate."
+        )
+        self.oauth_hint_label.setWordWrap(True)
+        conn_layout.addWidget(self.oauth_hint_label, 6, 0, 1, 2)
+
         # Connection management buttons
         conn_mgmt_layout = QHBoxLayout()
         self.save_connection_btn = QPushButton("Save Connection")
         self.save_connection_btn.clicked.connect(self.save_current_connection)
         conn_mgmt_layout.addWidget(self.save_connection_btn)
-        
+
         self.delete_connection_btn = QPushButton("Delete Connection")
         self.delete_connection_btn.clicked.connect(self.delete_saved_connection)
         conn_mgmt_layout.addWidget(self.delete_connection_btn)
-        
+
         conn_mgmt_layout.addStretch()
-        conn_layout.addLayout(conn_mgmt_layout, 5, 0, 1, 2)
-        
+        conn_layout.addLayout(conn_mgmt_layout, 7, 0, 1, 2)
+
         # Connection test buttons
         conn_btn_layout = QHBoxLayout()
+        self.sign_in_btn = QPushButton("Sign in")
+        self.sign_in_btn.setToolTip("Run the OAuth browser sign-in and cache the token")
+        self.sign_in_btn.clicked.connect(self.sign_in_oauth)
+        conn_btn_layout.addWidget(self.sign_in_btn)
+
         self.test_connection_btn = QPushButton("Test Connection")
         self.test_connection_btn.clicked.connect(self.test_connection)
         conn_btn_layout.addWidget(self.test_connection_btn)
-        
+
         self.discover_tables_btn = QPushButton("Discover Tables")
         self.discover_tables_btn.clicked.connect(self.discover_tables)
         conn_btn_layout.addWidget(self.discover_tables_btn)
-        
+
         conn_btn_layout.addStretch()
-        conn_layout.addLayout(conn_btn_layout, 6, 0, 1, 2)
+        conn_layout.addLayout(conn_btn_layout, 8, 0, 1, 2)
+
+        # Apply initial visibility based on the default auth method
+        self._on_auth_method_changed()
         
         layout.addWidget(conn_group)
         
@@ -1018,8 +1069,10 @@ class DatabricksDialog(QDialog):
             self.hostname_edit.setText(self.settings.value("hostname", ""))
             self.http_path_edit.setText(self.settings.value("http_path", ""))
             self.access_token_edit.setText(self.settings.value("access_token", ""))
-            
+            self._set_auth_method(self.settings.value("auth_method", AUTH_PAT))
+
             self.settings.endGroup()
+            self._on_auth_method_changed()
             
         except Exception as e:
             QgsMessageLog.logMessage(
@@ -1034,31 +1087,96 @@ class DatabricksDialog(QDialog):
         self.hostname_edit.clear()
         self.http_path_edit.clear()
         self.access_token_edit.clear()
-    
+
+    def _auth_method(self):
+        """Return the auth-method identifier for the selected combo entry."""
+        index = self.auth_method_combo.currentIndex()
+        if 0 <= index < len(AUTH_METHOD_LABELS):
+            return AUTH_METHOD_LABELS[index][1]
+        return AUTH_PAT
+
+    def _set_auth_method(self, method):
+        """Select the combo entry matching the given auth-method identifier."""
+        method = normalise_auth_method(method)
+        for i, (_label, value) in enumerate(AUTH_METHOD_LABELS):
+            if value == method:
+                self.auth_method_combo.setCurrentIndex(i)
+                return
+        self.auth_method_combo.setCurrentIndex(0)
+
+    def _on_auth_method_changed(self, *args):
+        """Show/hide the token field and OAuth hint based on the auth method."""
+        is_pat = self._auth_method() == AUTH_PAT
+        self.access_token_label.setVisible(is_pat)
+        self.access_token_edit.setVisible(is_pat)
+        self.oauth_hint_label.setVisible(not is_pat)
+        self.sign_in_btn.setVisible(not is_pat)
+
+    def _validate_connection_inputs(self, hostname, http_path, access_token, auth_method):
+        """Return True if the supplied fields are sufficient for the method."""
+        if not hostname or not http_path:
+            return False
+        if auth_method == AUTH_PAT and not access_token:
+            return False
+        return True
+
+    def sign_in_oauth(self):
+        """Run the OAuth browser sign-in up front so the token is cached."""
+        if not DATABRICKS_AVAILABLE:
+            QMessageBox.critical(self, "Missing Dependencies",
+                                 "databricks-sql-connector is not installed. Please install it first.")
+            return
+        hostname = self.hostname_edit.text().strip()
+        http_path = self.http_path_edit.text().strip()
+        if not all([hostname, http_path]):
+            QMessageBox.warning(self, "Missing Information",
+                                "Please fill in Server Hostname and HTTP Path before signing in.")
+            return
+
+        self.progress_dialog = QProgressDialog(
+            "Waiting for browser sign-in...", "Cancel", 0, 0, self)
+        self.progress_dialog.setWindowModality(Qt.WindowModal)
+        self.progress_dialog.show()
+
+        self.sign_in_thread = OAuthSignInThread(hostname, http_path)
+        self.sign_in_thread.finished.connect(self._on_signed_in)
+        self.sign_in_thread.start()
+
+    def _on_signed_in(self, success, message):
+        """Handle OAuth sign-in results."""
+        self.progress_dialog.close()
+        if success:
+            QMessageBox.information(self, "Databricks Sign-in", message)
+            self.discover_tables_btn.setEnabled(True)
+        else:
+            QMessageBox.critical(self, "Databricks Sign-in Failed", message)
+
     def save_current_connection(self):
         """Save current connection details"""
         connection_name = self.connection_name_edit.text().strip()
         hostname = self.hostname_edit.text().strip()
         http_path = self.http_path_edit.text().strip()
         access_token = self.access_token_edit.text().strip()
+        auth_method = self._auth_method()
         layer_prefix = self.layer_prefix_edit.text().strip()
-        
+
         if not connection_name:
-            QMessageBox.warning(self, "Missing Information", 
+            QMessageBox.warning(self, "Missing Information",
                               "Please provide a connection name.")
             return
-        
-        if not all([hostname, http_path, access_token]):
-            QMessageBox.warning(self, "Missing Information", 
-                              "Please fill in all connection fields.")
+
+        if not self._validate_connection_inputs(hostname, http_path, access_token, auth_method):
+            QMessageBox.warning(self, "Missing Information",
+                              "Please fill in all required connection fields.")
             return
-        
+
         try:
             # Save connection
             self.settings.beginGroup(f"DatabricksConnector/Connections/{connection_name}")
             self.settings.setValue("hostname", hostname)
             self.settings.setValue("http_path", http_path)
             self.settings.setValue("access_token", access_token)
+            self.settings.setValue("auth_method", auth_method)
             self.settings.endGroup()
             
             # Save as last used connection
@@ -1174,19 +1292,22 @@ import sys
         hostname = self.hostname_edit.text().strip()
         http_path = self.http_path_edit.text().strip()
         access_token = self.access_token_edit.text().strip()
-        
-        if not all([hostname, http_path, access_token]):
-            QMessageBox.warning(self, "Missing Information", 
-                              "Please fill in all connection fields.")
+        auth_method = self._auth_method()
+
+        if not self._validate_connection_inputs(hostname, http_path, access_token, auth_method):
+            QMessageBox.warning(self, "Missing Information",
+                              "Please fill in all required connection fields.")
             return
-        
+
         # Show progress dialog
-        self.progress_dialog = QProgressDialog("Testing connection...", "Cancel", 0, 0, self)
+        msg = ("Waiting for browser sign-in..." if auth_method == AUTH_OAUTH_U2M
+               else "Testing connection...")
+        self.progress_dialog = QProgressDialog(msg, "Cancel", 0, 0, self)
         self.progress_dialog.setWindowModality(Qt.WindowModal)
         self.progress_dialog.show()
-        
+
         # Start test thread
-        self.test_thread = ConnectionTestThread(hostname, http_path, access_token)
+        self.test_thread = ConnectionTestThread(hostname, http_path, access_token, auth_method)
         self.test_thread.finished.connect(self.on_connection_tested)
         self.test_thread.start()
     
@@ -1210,19 +1331,20 @@ import sys
         hostname = self.hostname_edit.text().strip()
         http_path = self.http_path_edit.text().strip()
         access_token = self.access_token_edit.text().strip()
-        
-        if not all([hostname, http_path, access_token]):
-            QMessageBox.warning(self, "Missing Information", 
+        auth_method = self._auth_method()
+
+        if not self._validate_connection_inputs(hostname, http_path, access_token, auth_method):
+            QMessageBox.warning(self, "Missing Information",
                               "Please test the connection first.")
             return
-        
+
         # Show progress dialog
         self.progress_dialog = QProgressDialog("Discovering spatial tables...", "Cancel", 0, 0, self)
         self.progress_dialog.setWindowModality(Qt.WindowModal)
         self.progress_dialog.show()
-        
+
         # Start discovery thread
-        self.discovery_thread = TableDiscoveryThread(hostname, http_path, access_token)
+        self.discovery_thread = TableDiscoveryThread(hostname, http_path, access_token, auth_method)
         self.discovery_thread.finished.connect(self.on_tables_discovered)
         self.discovery_thread.start()
     
@@ -1347,7 +1469,8 @@ import sys
         
         # Start loading thread
         self.loading_thread = LayerLoadingThread(
-            hostname, http_path, access_token, table, layer_name, max_features
+            hostname, http_path, access_token, table, layer_name, max_features,
+            auth_method=self._auth_method()
         )
         self.loading_thread.progress.connect(self.on_loading_progress)
         self.loading_thread.finished.connect(self.on_layer_loaded)
@@ -1390,9 +1513,10 @@ import sys
                         connection_config = {
                             'hostname': self.hostname_edit.text().strip(),
                             'http_path': self.http_path_edit.text().strip(),
-                            'access_token': self.access_token_edit.text().strip()
+                            'access_token': self.access_token_edit.text().strip(),
+                            'auth_method': self._auth_method()
                         }
-                        
+
                         # Get table info from loading thread
                         table_info = {}
                         if hasattr(self.loading_thread, 'table_info'):
@@ -1540,7 +1664,8 @@ import sys
                     
                     # Start loading thread for this geometry type
                     loading_thread = LayerLoadingThread(
-                        hostname, http_path, access_token, specific_table_info, layer_name, max_features
+                        hostname, http_path, access_token, specific_table_info, layer_name, max_features,
+                        auth_method=self._auth_method()
                     )
                     loading_thread.progress.connect(self.on_loading_progress)
                     loading_thread.finished.connect(self.on_additional_layer_loaded)
@@ -1600,6 +1725,7 @@ import sys
             layer.setCustomProperty("databricks/hostname", hostname)
             layer.setCustomProperty("databricks/http_path", http_path)
             layer.setCustomProperty("databricks/access_token", access_token)
+            layer.setCustomProperty("databricks/auth_method", self._auth_method())
             
             # Store table info
             table_info = self.loading_thread.table_info
@@ -1634,19 +1760,21 @@ import sys
         hostname = self.hostname_edit.text().strip()
         http_path = self.http_path_edit.text().strip()
         access_token = self.access_token_edit.text().strip()
-        
-        if not all([hostname, http_path, access_token]):
-            QMessageBox.warning(self, "Missing Connection", 
+        auth_method = self._auth_method()
+
+        if not self._validate_connection_inputs(hostname, http_path, access_token, auth_method):
+            QMessageBox.warning(self, "Missing Connection",
                               "Please test the connection first or fill in all connection fields.")
             return
-        
+
         try:
             connection_config = {
                 'hostname': hostname,
                 'http_path': http_path,
-                'access_token': access_token
+                'access_token': access_token,
+                'auth_method': auth_method
             }
-            
+
             query_dialog = DatabricksQueryDialog(connection_config, self)
             query_dialog.exec()
             
@@ -1687,15 +1815,18 @@ import sys
         
         hostname = connection_config['hostname']
         http_path = connection_config['http_path']
-        access_token = connection_config['access_token']
-        
+        access_token = connection_config.get('access_token', '')
+        auth_method = normalise_auth_method(connection_config.get('auth_method', AUTH_PAT))
+
         base_uri = f"databricks://{hostname}:443{http_path}"
-        
+
         params = {
-            'access_token': access_token,
-            'table': table_info['full_name']
+            'table': table_info['full_name'],
+            'auth_method': auth_method
         }
-        
+        if access_token:
+            params['access_token'] = access_token
+
         if table_info.get('geometry_column'):
             params['geom_column'] = table_info['geometry_column']
         
@@ -1726,11 +1857,9 @@ class DatabaseStructureThread(QThread):
             self.progress.emit("Loading database structure...")
             
             connection = sql.connect(
-                server_hostname=self.connection_config['hostname'],
-                http_path=self.connection_config['http_path'],
-                access_token=self.connection_config['access_token']
+                **connect_kwargs_from_config(self.connection_config)
             )
-            
+
             with connection.cursor() as cursor:
                 # Use information_schema to get only accessible tables and columns
                 self.progress.emit("Loading accessible database structure...")
@@ -1835,11 +1964,9 @@ class QueryExecutionThread(QThread):
             self.progress.emit("Connecting to Databricks...")
             
             connection = sql.connect(
-                server_hostname=self.connection_config['hostname'],
-                http_path=self.connection_config['http_path'],
-                access_token=self.connection_config['access_token']
+                **connect_kwargs_from_config(self.connection_config)
             )
-            
+
             self.progress.emit("Executing query...")
             
             with connection.cursor() as cursor:
@@ -1883,11 +2010,9 @@ class QueryLayerCreationThread(QThread):
             self.progress.emit("Connecting to Databricks...")
             
             connection = sql.connect(
-                server_hostname=self.connection_config['hostname'],
-                http_path=self.connection_config['http_path'],
-                access_token=self.connection_config['access_token']
+                **connect_kwargs_from_config(self.connection_config)
             )
-            
+
             self.progress.emit("Analyzing query for geometry columns...")
             
             # First, check if we need to modify the query for geometry conversion

--- a/databricks_dbsql_connector/databricks_genie.py
+++ b/databricks_dbsql_connector/databricks_genie.py
@@ -30,6 +30,13 @@ from qgis.core import (
     QgsCoordinateReferenceSystem
 )
 
+from .databricks_auth import (
+    AUTH_PAT,
+    normalise_auth_method,
+    connect_kwargs,
+    get_bearer_token,
+)
+
 
 # ---------------------------------------------------------------------------
 # Helpers (reused from databricks_dialog.py patterns)
@@ -144,17 +151,22 @@ class GenieSpaceListThread(QThread):
     spaces_loaded = pyqtSignal(list)   # [{id, title}, ...]
     error_occurred = pyqtSignal(str)
 
-    def __init__(self, hostname, access_token, parent=None):
+    def __init__(self, hostname, access_token, parent=None,
+                 http_path=None, auth_method=AUTH_PAT):
         super().__init__(parent)
         self.hostname = hostname
         self.access_token = access_token
+        self.http_path = http_path
+        self.auth_method = auth_method
 
     def run(self):
         try:
+            token = get_bearer_token(self.hostname, self.http_path,
+                                     self.access_token, self.auth_method)
             data = _api_request(
                 self.hostname,
                 '/api/2.0/genie/spaces',
-                self.access_token,
+                token,
             )
             spaces = []
             for sp in data.get('spaces', []):
@@ -182,10 +194,13 @@ class GenieApiThread(QThread):
     _MAX_POLL_SECS = 600  # 10 min
 
     def __init__(self, hostname, access_token, space_id, question,
-                 conversation_id=None, parent=None):
+                 conversation_id=None, parent=None,
+                 http_path=None, auth_method=AUTH_PAT):
         super().__init__(parent)
         self.hostname = hostname
         self.access_token = access_token
+        self.http_path = http_path
+        self.auth_method = auth_method
         self.space_id = space_id
         self.question = question
         self.conversation_id = conversation_id
@@ -244,6 +259,11 @@ class GenieApiThread(QThread):
 
     def run(self):
         try:
+            # Resolve the bearer token (refreshes OAuth tokens if needed).
+            self.access_token = get_bearer_token(
+                self.hostname, self.http_path,
+                self.access_token, self.auth_method)
+
             # 1. Start or continue conversation
             if self.conversation_id:
                 path = (f'/api/2.0/genie/spaces/{self.space_id}'
@@ -322,11 +342,13 @@ class GenieReQueryThread(QThread):
     status_update = pyqtSignal(str)
 
     def __init__(self, hostname, http_path, access_token,
-                 query_statement, geom_col, parent=None):
+                 query_statement, geom_col, parent=None,
+                 auth_method=AUTH_PAT):
         super().__init__(parent)
         self.hostname = hostname
         self.http_path = http_path
         self.access_token = access_token
+        self.auth_method = auth_method
         self.query_statement = query_statement
         self.geom_col = geom_col
 
@@ -349,9 +371,8 @@ class GenieReQueryThread(QThread):
             )
 
             conn = dbsql.connect(
-                server_hostname=self.hostname,
-                http_path=self.http_path,
-                access_token=self.access_token,
+                **connect_kwargs(self.hostname, self.http_path,
+                                 self.access_token, self.auth_method)
             )
             with conn.cursor() as cursor:
                 cursor.execute(wrapped_query)
@@ -517,31 +538,40 @@ class GenieDialog(QDialog):
             self._on_connection_changed(0)
 
     def _get_connection(self):
-        """Return (hostname, http_path, access_token) for the selected connection."""
+        """Return (hostname, http_path, access_token, auth_method) for the
+        selected connection."""
         name = self.conn_combo.currentText()
         if not name:
-            return None, None, None
+            return None, None, None, AUTH_PAT
         base = f"DatabricksConnector/Connections/{name}"
         hostname = self.settings.value(f"{base}/hostname", "")
         http_path = self.settings.value(f"{base}/http_path", "")
         token = self.settings.value(f"{base}/access_token", "")
-        return hostname, http_path, token
+        auth_method = normalise_auth_method(
+            self.settings.value(f"{base}/auth_method", AUTH_PAT))
+        return hostname, http_path, token, auth_method
+
+    @staticmethod
+    def _creds_ready(hostname, token, auth_method):
+        """True if there is enough to authenticate (token, or OAuth)."""
+        return bool(hostname) and (bool(token) or auth_method != AUTH_PAT)
 
     def _on_connection_changed(self, _index):
         """When connection changes, refresh the Genie Space list."""
-        hostname, _hp, token = self._get_connection()
-        if not hostname or not token:
+        hostname, http_path, token, auth_method = self._get_connection()
+        if not self._creds_ready(hostname, token, auth_method):
             self.space_combo.clear()
             return
-        self._fetch_spaces(hostname, token)
+        self._fetch_spaces(hostname, token, http_path, auth_method)
 
-    def _fetch_spaces(self, hostname, token):
+    def _fetch_spaces(self, hostname, token, http_path=None, auth_method=AUTH_PAT):
         """Kick off a background thread to list Genie Spaces."""
         self.space_combo.clear()
         self.space_combo.addItem("Loading...")
         self.space_combo.setEnabled(False)
 
-        self._space_thread = GenieSpaceListThread(hostname, token, self)
+        self._space_thread = GenieSpaceListThread(
+            hostname, token, self, http_path=http_path, auth_method=auth_method)
         self._space_thread.spaces_loaded.connect(self._on_spaces_loaded)
         self._space_thread.error_occurred.connect(self._on_spaces_error)
         self._space_thread.start()
@@ -643,8 +673,8 @@ class GenieDialog(QDialog):
         if not question:
             return
 
-        hostname, http_path, token = self._get_connection()
-        if not hostname or not token:
+        hostname, http_path, token, auth_method = self._get_connection()
+        if not self._creds_ready(hostname, token, auth_method):
             QMessageBox.warning(self, "No Connection",
                                 "Please select a saved connection first.")
             return
@@ -681,6 +711,7 @@ class GenieDialog(QDialog):
             hostname, token, space_id, api_question,
             conversation_id=self._conversation_id,
             parent=self,
+            http_path=http_path, auth_method=auth_method,
         )
         self._api_thread.response_received.connect(self._on_response)
         self._api_thread.error_occurred.connect(self._on_api_error)
@@ -940,8 +971,9 @@ class GenieDialog(QDialog):
                 geom_idx, f"genie_{geom_col}")
         else:
             # Path B: need to re-query via DB to get WKT — use thread for I/O
-            hostname, http_path, token = self._get_connection()
-            if not all([hostname, http_path, token]):
+            hostname, http_path, token, auth_method = self._get_connection()
+            if not (hostname and http_path
+                    and self._creds_ready(hostname, token, auth_method)):
                 QMessageBox.warning(
                     self, "Missing Connection",
                     "HTTP Path is required for non-WKT geometry re-query. "
@@ -959,7 +991,8 @@ class GenieDialog(QDialog):
             self._pending_layer_geom_col = geom_col
             self._requery_thread = GenieReQueryThread(
                 hostname, http_path, token,
-                self._current_query, geom_col, parent=self)
+                self._current_query, geom_col, parent=self,
+                auth_method=auth_method)
             self._requery_thread.data_ready.connect(self._on_requery_done)
             self._requery_thread.error_occurred.connect(self._on_layer_error)
             self._requery_thread.status_update.connect(

--- a/databricks_dbsql_connector/databricks_live_layer.py
+++ b/databricks_dbsql_connector/databricks_live_layer.py
@@ -26,6 +26,8 @@ try:
 except ImportError:
     DATABRICKS_AVAILABLE = False
 
+from .databricks_auth import connect_kwargs_from_config
+
 
 class LiveLayerFetchThread(QThread):
     """Background thread for fetching data from Databricks with viewport filtering"""
@@ -119,11 +121,9 @@ class LiveLayerFetchThread(QThread):
             self.progress.emit("Connecting to Databricks...")
             
             connection = sql.connect(
-                server_hostname=self.connection_config['hostname'],
-                http_path=self.connection_config['http_path'],
-                access_token=self.connection_config['access_token']
+                **connect_kwargs_from_config(self.connection_config)
             )
-            
+
             if self._cancelled:
                 connection.close()
                 self.finished.emit(False, "Fetch cancelled", [])

--- a/databricks_dbsql_connector/databricks_provider.py
+++ b/databricks_dbsql_connector/databricks_provider.py
@@ -26,6 +26,7 @@ import logging
 from shapely import wkt, wkb
 from shapely.geometry import Point, LineString, Polygon
 from databricks import sql
+from .databricks_auth import AUTH_PAT, normalise_auth_method, connect_kwargs
 
 
 class DatabricksFeatureIterator(QgsAbstractFeatureIterator):
@@ -130,6 +131,7 @@ class DatabricksProvider(QgsVectorDataProvider):
         self.port = 443
         self.http_path = ''
         self.access_token = ''
+        self.auth_method = AUTH_PAT
         self.table_name = ''
         self.schema_name = ''
         self.catalog_name = ''
@@ -156,7 +158,10 @@ class DatabricksProvider(QgsVectorDataProvider):
             
             if 'access_token' in params:
                 self.access_token = params['access_token'][0]
-            
+
+            if 'auth_method' in params:
+                self.auth_method = normalise_auth_method(params['auth_method'][0])
+
             if 'table' in params:
                 table_parts = params['table'][0].split('.')
                 if len(table_parts) == 3:
@@ -178,15 +183,15 @@ class DatabricksProvider(QgsVectorDataProvider):
     
     def is_valid_config(self) -> bool:
         """Check if configuration is valid"""
-        return bool(self.hostname and self.access_token and self.table_name)
-    
+        token_ok = bool(self.access_token) or self.auth_method != AUTH_PAT
+        return bool(self.hostname and token_ok and self.table_name)
+
     def _connect(self):
         """Establish connection to Databricks"""
         try:
             self.connection = sql.connect(
-                server_hostname=self.hostname,
-                http_path=self.http_path,
-                access_token=self.access_token
+                **connect_kwargs(self.hostname, self.http_path,
+                                 self.access_token, self.auth_method)
             )
             QgsMessageLog.logMessage(
                 "Connected to Databricks successfully",

--- a/databricks_dbsql_connector/metadata.txt
+++ b/databricks_dbsql_connector/metadata.txt
@@ -3,7 +3,7 @@ name=Databricks DBSQL Connector
 qgisMinimumVersion=3.16
 qgisMaximumVersion=4.99
 description=Connect QGIS to Databricks SQL warehouses and access geospatial data directly from Unity Catalog
-version=1.3.1
+version=1.4.0
 author=Danny Wong
 email=danny.wong@databricks.com
 
@@ -33,7 +33,7 @@ server=False
 about=A QGIS plugin that provides direct connectivity to Databricks SQL warehouses, allowing you to load and display geospatial data from Unity Catalog tables directly in QGIS.
 
     Features:
-    - Direct Databricks SQL connection using personal access tokens
+    - Direct Databricks SQL connection using personal access tokens or OAuth (browser login / SSO)
     - Full support for GEOGRAPHY and GEOMETRY data types
     - Live Layers: viewport-based auto-refresh for working with large datasets
     - Browser Panel integration for browsing catalogs, schemas, and tables
@@ -46,7 +46,7 @@ about=A QGIS plugin that provides direct connectivity to Databricks SQL warehous
 
     Requirements:
     - Databricks SQL Warehouse access
-    - Personal Access Token with appropriate permissions
+    - Authentication: a Personal Access Token, or OAuth (browser login / SSO)
     - Unity Catalog tables with GEOGRAPHY or GEOMETRY columns
 
     Python Dependencies (installed automatically):
@@ -55,7 +55,17 @@ about=A QGIS plugin that provides direct connectivity to Databricks SQL warehous
     For installation instructions and documentation, visit the GitHub repository.
 
 # Changelog
-changelog=1.3.1 - Fix dependency installation on QGIS 4 macOS
+changelog=1.4.0 - OAuth (browser login / SSO) authentication
+    - New: Auth Method selector — choose Personal Access Token or OAuth (U2M)
+    - New: OAuth User-to-Machine browser sign-in; no Personal Access Token required
+    - New: "Sign in" button primes the OAuth flow so the browser opens only once
+    - New: OAuth tokens cached in a permission-restricted file under the QGIS profile,
+      so connections, live-layer refreshes, the Browser panel and Genie reuse them silently
+    - New: Genie REST calls obtain a bearer token from the cached OAuth session
+    - Changed: all connections now flow through a single auth factory (databricks_auth.py)
+    - Back-compat: existing Personal Access Token connections and layers keep working unchanged
+
+    1.3.1 - Fix dependency installation on QGIS 4 macOS
     - Fixed: thrift build failure caused by pip build isolation spawning broken subprocess
     - Fixed: "Couldn't load SIP module" error during dependency installation
     - Fixed: QGIS opening a second instance during pip install

--- a/package_plugin.py
+++ b/package_plugin.py
@@ -24,6 +24,7 @@ PLUGIN_NAME = "databricks_dbsql_connector"
 INCLUDE_FILES = [
     "__init__.py",
     "_qt6_compat.py",
+    "databricks_auth.py",
     "metadata.txt",
     "LICENSE",
     "requirements.txt",


### PR DESCRIPTION
Introduce a single authentication factory (databricks_auth.py) that all 16 sql.connect call sites and Genie's REST API now route through, and add OAuth User-to-Machine (browser login) alongside the existing Personal Access Token auth.

- databricks_auth.py: connect_kwargs()/connect_kwargs_from_config() build the sql.connect kwargs per auth method; QgisOAuthPersistence caches OAuth tokens in a permission-restricted JSON file under the QGIS profile dir, keyed by hostname, so the browser opens once and all connections refresh silently; get_bearer_token() resolves a REST bearer token for Genie (refreshing via a lightweight ping when the cached JWT is near expiry).
- Dialog: Auth Method dropdown with conditional token field, a "Sign in" button that primes the OAuth flow up front, and auth_method threaded through every thread, saved connection, layer customProperty and provider URI.
- Browser, connector (layer refresh + live-mode toggle), provider, live layer and Genie all carry auth_method and use the factory.
- Validation no longer requires an access token when OAuth is selected.
- Back-compat: missing/blank auth_method falls back to PAT, so existing saved connections and layers keep working unchanged.
- Packaging/docs: include databricks_auth.py, bump to 1.4.0, update changelog and README (auth methods, OAuth troubleshooting).